### PR TITLE
Simplify Namespaces in Save and SaveSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.0](https://github.com/stone-tech-inc/rimhistory/tree/v0.7.0) (2022-02-25)
+
+### Improvements
+
+* Reduce memory usage by carrying each dataset as a pandas DataFrame with no additional copies ([#21][i21])
+* Simplify the namespaces in Save and SaveSeries ([#22][i22])
+
+### Testing
+
+* Update test cases affected by changes to namespaces
+
+[i21]: https://github.com/stone-tech-inc/rimhistory/issues/21
+[i22]: https://github.com/stone-tech-inc/rimhistory/issues/22
+
 ## [0.6.0](https://github.com/stone-tech-inc/rimhistory/tree/v0.6.0) (2022-02-25)
 
 ### New features

--- a/tests/test_class_save.py
+++ b/tests/test_class_save.py
@@ -6,6 +6,8 @@ import pathlib
 import shutil
 import xml.etree.ElementTree
 
+import pandas
+
 from save import Save
 
 
@@ -19,17 +21,17 @@ def test_class_save_pawn(test_data_list: list) -> None:
     None
     """
     save = Save(path_to_save_file=test_data_list[0])
-    pawn_data = save.data.dataset.pawn.dictionary_list
+    pawn_df = save.data.pawn
 
     # Test the pawn property's data type
-    assert isinstance(pawn_data, list)
+    assert isinstance(pawn_df, pandas.core.frame.DataFrame)
 
     # Test the number of pawns detected
-    assert 1 <= len(pawn_data) <= 150
-    logging.debug("Found pawn = %s", pawn_data[0]["pawn_id"])
+    assert 1 <= len(pawn_df.index) <= 150
+    logging.debug("Found pawn = \n%s", pawn_df["pawn_id"].head(1))
 
     # Test the length of the first pawn_id
-    assert 3 <= len(pawn_data[0]["pawn_id"]) <= 50
+    assert 3 <= len(pawn_df["pawn_id"].head(1).to_string()) <= 50
 
 
 def test_class_save_root(test_data_list: list) -> None:
@@ -147,5 +149,5 @@ def test_uncompressed_file(test_data_list: list, tmp_path: pathlib.Path) -> None
 
     # Perform basic checks on the created Save object
     assert isinstance(save, Save)
-    assert "plant" in save.data.dataset.keys()
-    assert 1 <= len(save.data.dataset.pawn) <= 50
+    assert "plant" in save.data.keys()
+    assert 1 <= len(save.data.pawn.index) <= 50

--- a/tests/test_class_save_series.py
+++ b/tests/test_class_save_series.py
@@ -40,7 +40,7 @@ def test_class_save_series(test_data_directory: pathlib.Path, test_save_file_reg
     series = SaveSeries(save_dir_path=test_data_directory,
                         save_file_regex_pattern=test_save_file_regex)
     expected_count = 24232
-    actual_count = len(series.dataset.plant.dataframe.index)
+    actual_count = len(series.data.plant.index)
     logging.debug("Dataframe aggregation test result:\nExpected count: %d\nActual count: %d",
                   expected_count, actual_count)
 
@@ -90,4 +90,4 @@ def test_load_save_data_worker_task(test_data_directory: pathlib.Path, test_save
     # Validate that the new save file was processed successfully
     assert isinstance(save, Save)
     assert len(series.dictionary) == 4
-    assert len(save.data.dataset.plant.dataframe.index) == 11169
+    assert len(save.data.plant.index) == 11169

--- a/tests/test_mod_list.py
+++ b/tests/test_mod_list.py
@@ -1,5 +1,4 @@
 """Test the extract_mod_list function that extracts data about installed mods from a save file"""
-import json
 import logging
 
 from save import Save
@@ -15,14 +14,19 @@ def test_mod_list(test_data_list: list) -> None:
     Returns:
     None
     """
-    mod_list = Save(path_to_save_file=test_data_list[0]).data.dataset.mod.dictionary_list
-    assert 0 < len(mod_list) < 20000
-    logging.debug("List of installed mods = \n%s", json.dumps(mod_list, indent=4))
+    mod_df = Save(path_to_save_file=test_data_list[0]).data.mod
+    assert 0 < len(mod_df.index) < 20000
+    logging.debug("List of installed mods = \n%s", mod_df)
 
-    expected_mod_attributes = ["mod_id", "mod_name", "mod_steam_id"]
-    sample_mod = mod_list[0]
+    expected_mod_attributes = [
+        "mod_id",
+        "mod_name",
+        "mod_steam_id",
+        "time_ticks",
+    ]
+    sample_mod = mod_df.head(1)
     logging.debug("Checking sample mod for expected attributes\nExpected attributes = %s\nSample "
-                  "mod:\n%s", expected_mod_attributes, json.dumps(sample_mod, indent=4))
+                  "mod:\n%s", expected_mod_attributes, sample_mod)
 
     for attribute in expected_mod_attributes:
         assert attribute in sample_mod.keys()

--- a/tests/test_pawn_ambient_temperature.py
+++ b/tests/test_pawn_ambient_temperature.py
@@ -14,7 +14,7 @@ def test_pawn_ambient_temperature(test_data_list: list) -> None:
     Returns:
     None
     """
-    pawn_data = Save(path_to_save_file=test_data_list[0]).data.dataset.pawn.dictionary_list
-    logging.debug(pawn_data[0].keys())
+    pawn_df = Save(path_to_save_file=test_data_list[0]).data.pawn
+    logging.debug("Sample pawn data =\n%s", pawn_df.head(5))
 
-    assert "pawn_ambient_temperature" in pawn_data[0].keys()
+    assert "pawn_ambient_temperature" in pawn_df.columns

--- a/tests/test_pawn_data.py
+++ b/tests/test_pawn_data.py
@@ -12,7 +12,7 @@ def test_get_pawn_count(test_data_list: list) -> None:
     Returns:
     None
     """
-    pawn_data = Save(path_to_save_file=test_data_list[0]).data.dataset.pawn.dataframe
-    pawn_data.query("current_record == True", inplace=True)
+    pawn_df = Save(path_to_save_file=test_data_list[0]).data.pawn
+    pawn_df.query("current_record == True", inplace=True)
 
-    assert len(pawn_data.index) == 5
+    assert len(pawn_df.index) == 5

--- a/tests/test_plant_dataframe.py
+++ b/tests/test_plant_dataframe.py
@@ -17,11 +17,10 @@ def test_plant_dataframe(test_data_list: list) -> None:
     None
     """
     save = Save(path_to_save_file=test_data_list[0])
-    plant_dataframe = save.data.dataset.plant.dataframe
+    plant_df = save.data.plant
 
     # Test the data type of the frame
-    logging.debug("type(plant_dataframe) = %s", type(plant_dataframe))
-    assert isinstance(plant_dataframe, pandas.core.frame.DataFrame)
+    assert isinstance(plant_df, pandas.core.frame.DataFrame)
 
     # Test the expected columns
     expected_columns = [
@@ -36,17 +35,16 @@ def test_plant_dataframe(test_data_list: list) -> None:
         "time_ticks",
     ]
     logging.debug("Expected columns (count = %d) = %s", len(expected_columns), expected_columns)
-    logging.debug("Actual columns (count = %d) = %s", len(plant_dataframe.columns),
-                  plant_dataframe.columns)
-    assert len(plant_dataframe.columns) == len(expected_columns)
+    logging.debug("Actual columns (count = %d) = %s", len(plant_df.columns), plant_df.columns)
+    assert len(plant_df.columns) == len(expected_columns)
 
     for column in expected_columns:
-        assert column in plant_dataframe.columns
+        assert column in plant_df.columns
 
     # Test the expected number of rows
     row_count_minimum = 10000
     row_count_maximum = 40000
     logging.debug("Expected rows in dataframe is between %d and %d", row_count_minimum,
                   row_count_maximum)
-    logging.debug("Actual rows in dataframe = %d", len(plant_dataframe.index))
-    assert row_count_minimum <= len(plant_dataframe.index) <= row_count_maximum
+    logging.debug("Actual rows in dataframe = %d", len(plant_df.index))
+    assert row_count_minimum <= len(plant_df.index) <= row_count_maximum

--- a/tests/test_plant_growth_chart.py
+++ b/tests/test_plant_growth_chart.py
@@ -17,10 +17,10 @@ def test_plant_growth_chart(tmp_path: pathlib.Path, test_data_list: list) -> Non
     Returns:
     None
     """
-    plant_dataframe = Save(path_to_save_file=test_data_list[0]).data.dataset.plant.dataframe
+    plant_df = Save(path_to_save_file=test_data_list[0]).data.plant
     labels = {"plant_growth_bin": "Plant growth (%)"}
     plant_growth_chart_html = view.summary_report.get_histogram_html(
-        dataframe=plant_dataframe,
+        df=plant_df,
         x_axis_field="plant_growth_bin",
         labels=labels
     )

--- a/view/summary_report.py
+++ b/view/summary_report.py
@@ -2,7 +2,6 @@
 
 import pathlib
 
-import bunch
 import dominate
 from dominate.util import raw
 from dominate.tags import attr, div, h1, h2, h3, li, link, p, ul
@@ -12,28 +11,29 @@ import plotly.express
 from save import SaveSeries
 
 
-def get_environment_section(pawn_data: pandas.core.frame.DataFrame, weather_data: dict) -> None:
+def get_environment_section(series: SaveSeries) -> None:
     """Build the environment and weather section of the report
 
     Parameters:
-    pawn_data (pandas.core.frame.DataFrame): The dataframe containing pawn data
-    weather_data (dict): A dictionary containing weather data for the map being analyzed
+    series (SaveSeries): The SaveSeries object containing the plant data
 
     Returns:
     None
     """
+    weather_df = series.data.weather
+    pawn_df = series.latest_save.data.pawn
     h2("Environment and Weather")
     h3("Weather")
 
     with ul():
-        li(f"Current weather: {weather_data['weather_current']}")
-        li(f"Last weather: {weather_data['weather_last']}")
-        li(f"Current weather age: {weather_data['weather_current_age']}")
+        li(f"Current weather: {weather_df['weather_current']}")
+        li(f"Last weather: {weather_df['weather_last']}")
+        li(f"Current weather age: {weather_df['weather_current_age']}")
 
     h3("Pawn Ambient Temperatures")
 
     with ul():
-        for _, pawn in pawn_data.iterrows():
+        for _, pawn in pawn_df.iterrows():
             ambient_temperature = round(float(pawn['pawn_ambient_temperature']), 1)
             ambient_temperature_string = f"{ambient_temperature}&#176;C"
             pawn_temperature_string = f"{ambient_temperature_string} temperature felt by \
@@ -41,19 +41,18 @@ def get_environment_section(pawn_data: pandas.core.frame.DataFrame, weather_data
             li(raw(pawn_temperature_string))
 
 
-def get_histogram_html(dataframe: pandas.core.frame.DataFrame, x_axis_field: str,
-                       labels: dict) -> str:
+def get_histogram_html(df: pandas.core.frame.DataFrame, x_axis_field: str, labels: dict) -> str:
     """Return the HTML for a histogram chart
 
     Parameters:
-    dataframe (pandas.core.frame.DataFrame): The pandas DataFrame to use in the chart
+    df (pandas.core.frame.DataFrame): The pandas DataFrame to use in the chart
     x_axis_field (str): The field to use for the x-axis series
     labels (dict): A dictionary with the chart labels metadata
 
     Returns:
     str: A histogram chart HTML
     """
-    fig = plotly.express.histogram(dataframe, x=x_axis_field, labels=labels)
+    fig = plotly.express.histogram(df, x=x_axis_field, labels=labels)
     fig.update_layout(bargap=0.05, yaxis_title_text="Count")
 
     return fig.to_html(full_html=False)
@@ -75,11 +74,11 @@ def generate_summary_report(save_dir_path: pathlib.Path, file_regex_pattern: str
         save_dir_path=save_dir_path,
         save_file_regex_pattern=file_regex_pattern
     )
-    save = series.latest_save["save"]
+    save = series.latest_save
     doc = dominate.document(title='RimWorld Save Game Summary Report')
-    current_pawn_data = save.data.dataset.pawn.dataframe.query("(current_record == True) and \
-                                                               (is_humanoid_colonist == True)")
-    current_pawn_data.reset_index(drop=True, inplace=True)
+    current_pawn_df = save.data.pawn.query("(current_record == True) and \
+                                           (is_humanoid_colonist == True)")
+    current_pawn_df.reset_index(drop=True, inplace=True)
 
     with doc.head:
         link(rel='stylesheet', href='style.css')
@@ -92,10 +91,10 @@ def generate_summary_report(save_dir_path: pathlib.Path, file_regex_pattern: str
             p(save.data.game_version)
             h2("File Size")
             p(f"{save.data.file_size} bytes")
-            h2(f"Installed Mods ({len(save.data.dataset.mod.dictionary_list)})")
+            h2(f"Installed Mods ({len(save.data.mod.index)})")
 
             with ul():
-                for mod in save.data.dataset.mod.dictionary_list:
+                for _, mod in save.data.mod.iterrows():
                     mod_list_item_content = mod["mod_name"]
                     mod_steam_id = mod["mod_steam_id"]
 
@@ -104,43 +103,36 @@ def generate_summary_report(save_dir_path: pathlib.Path, file_regex_pattern: str
 
                     li(mod_list_item_content)
 
-            h2(f"Colonists ({len(current_pawn_data.index)})")
+            h2(f"Colonists ({len(current_pawn_df.index)})")
 
             with ul():
-                for _, pawn in current_pawn_data.iterrows():
+                for _, pawn in current_pawn_df.iterrows():
                     li(f"{pawn['pawn_name_full']}, age {pawn['pawn_biological_age']}")
 
-            get_plant_section(
-                current_plant_dataset=save.data.dataset.plant,
-                series_plant_dataset=series.dataset.plant
-            )
-            get_environment_section(
-                pawn_data=current_pawn_data,
-                weather_data=save.data.dataset.weather.dictionary_list[0]
-            )
+            get_plant_section(series=series)
+            get_environment_section(series=series)
 
     with open(output_path, "w", encoding="utf_8") as output_file:
         output_file.write(str(doc))
 
 
-def get_plant_section(current_plant_dataset: bunch.Bunch, series_plant_dataset: bunch.Bunch)\
-        -> None:
+def get_plant_section(series: SaveSeries) -> None:
     """Build the plant section of the report
 
     Parameters:
-    current_plant_dataframe (bunch.Bunch): The plant dataset for the current save
-    series_plant_dataframe (bunch.Bunch): The plant dataset for all saves in the series
+    series (SaveSeries): The SaveSeries object containing the plant data
 
     Returns:
     None
     """
-
-    h2(f"Plants ({len(current_plant_dataset.dictionary_list)})")
+    current_plant_df = series.latest_save.data.plant
+    series_plant_df = series.data.plant
+    h2(f"Plants ({len(current_plant_df.index)})")
 
     with ul():
         displayed_plant_types = []
 
-        for plant in current_plant_dataset.dictionary_list:
+        for _, plant in current_plant_df.iterrows():
             if plant['plant_definition'] in displayed_plant_types:
                 continue
 
@@ -155,24 +147,24 @@ def get_plant_section(current_plant_dataset: bunch.Bunch, series_plant_dataset: 
             if len(displayed_plant_types) >= 20:
                 break
 
-    plant_dataframe = current_plant_dataset.dataframe
-    p(raw(plant_dataframe.head().to_html()))
-    p(raw(plant_dataframe.tail().to_html()))
-    p(raw(plant_dataframe.describe().to_html()))
-    p(raw(plant_dataframe["plant_definition"].value_counts().to_frame().to_html()))
+    plant_df = current_plant_df
+    p(raw(plant_df.head().to_html()))
+    p(raw(plant_df.tail().to_html()))
+    p(raw(plant_df.describe().to_html()))
+    p(raw(plant_df["plant_definition"].value_counts().to_frame().to_html()))
     raw(
         get_histogram_html(
-            dataframe=plant_dataframe,
+            df=plant_df,
             x_axis_field="plant_growth_bin",
             labels={"plant_growth_bin": "Plant growth (%)"}
         )
     )
-    p(raw(series_plant_dataset.dataframe.head().to_html()))
-    p(raw(series_plant_dataset.dataframe.tail().to_html()))
-    p(raw(series_plant_dataset.dataframe.describe().to_html()))
+    p(raw(series_plant_df.head().to_html()))
+    p(raw(series_plant_df.tail().to_html()))
+    p(raw(series_plant_df.describe().to_html()))
 
     # Plant chart #1 - Total population
-    plant_agg_df = series_plant_dataset.dataframe\
+    plant_agg_df = series_plant_df\
         .groupby(["time_ticks"])\
         .agg({"plant_id": "count"})
     fig = plotly.express.line(
@@ -184,7 +176,7 @@ def get_plant_section(current_plant_dataset: bunch.Bunch, series_plant_dataset: 
     raw(fig.to_html(full_html=False))
 
     # Plant chart #2 - By species
-    plant_agg_by_species_df = series_plant_dataset.dataframe[
+    plant_agg_by_species_df = series_plant_df[
         ["time_ticks", "plant_definition", "plant_id"]
     ]
     plant_agg_by_species_df = plant_agg_by_species_df\


### PR DESCRIPTION
### Improvements

* Reduce memory usage by carrying each dataset as a pandas DataFrame with no additional copies (closes [#21][i21])
* Simplify the namespaces in Save and SaveSeries (closes [#22][i22])

### Testing

* Update test cases affected by changes to namespaces

[i21]: https://github.com/stone-tech-inc/rimhistory/issues/21
[i22]: https://github.com/stone-tech-inc/rimhistory/issues/22
